### PR TITLE
Improvements in dialog handling and test page url

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -50,7 +50,7 @@ gulp.task('test', ['build'], function (cb) {
 
     process.env.NODE_PATH = PACKAGE_SEARCH_PATH;
 
-    var child = childProcess.spawn(testCafeCmd, ['electron:' + appPath, 'test/fixtures/**/*-test.js', '-s', '.screenshots'], { stdio: 'inherit' });
+    var child = childProcess.spawn(testCafeCmd, ['electron:' + appPath, 'test/fixtures/**/*test.js', '-s', '.screenshots'], { stdio: 'inherit' });
 
     child.on('error', function (error) {
         cb(error);

--- a/README.md
+++ b/README.md
@@ -87,7 +87,8 @@ testCafe
 
 ### Specifying Target Webpage in Test Code
 
-In most cases, the target webpage is the main application page specified via the `mainWindowUrl` configuration option.
+In most cases, the target webpage is the main application page specified via the `mainWindowUrl` configuration option. 
+You don't have to specify it in the fixture. Also you can use the `mainWindowUrl` helper.
 
 ```json
 {
@@ -96,10 +97,19 @@ In most cases, the target webpage is the main application page specified via the
 ```
 
 ```js
+fixture `Electron test`;
+```
+
+```js
+import { mainWindowUrl } from 'testcafe-browser-provider-electron';
+
+fixture `Electron test`
+    .page(mainWindowUrl());
+```
+```js
 fixture `Electron test`
     .page('./index.html');
 ```
-
 However, you can specify any application page if your app contains more than one.
 
 ```js
@@ -128,7 +138,8 @@ __Optional.__ Overrides application command line arguments with the values speci
 ### electronPath
 
 __Optional__. Specifies a path to the electron binary. If `electronPath` is not specified, the [electron package](https://www.npmjs.com/package/electron) should be installed.
- On macOS, it can be either a path to the `electron` binary, or a path to the entire Electron.app (e.g. `/Applications/Electron.app`).
+ On macOS, it can be either a path to the `electron` binary, or a path to the entire Electron.app (e.g. `/Applications/Electron.app`). It may be necessary to stop all other running 
+ instances of the specified Electron binary.
 
 ### enableNavigateEvents
 
@@ -349,6 +360,16 @@ test('Should open properties of element', async t => {
  * `error-box`,
  * `certificate-trust-dialog`.
  
+ If a handler was set using `setElectronDialogHandler`, but no dialogs were opened during test case execution, the test will be failed with the following error: 
+ ```
+ Error: An expected Electron dialog didn\'t appear
+ ```
+ 
+ Also, if a dialog appears during test case execution, but there is no installed dialog handler, the test also will be failed with the error:
+ ```
+ Error: An unexpected Electron dialog appeared
+ ```
+ 
  **Example**
  
  ```js
@@ -375,5 +396,25 @@ test('Test project opening', async t => {
 });
 ```
 
+### mainWindowUrl
+ Returns an absolute url to the tested page. If tested page url cannot be figured (e.g. is is used outside of a test context), 
+ returns `about:blank`. It can be used as a test page URL in `fixture.page` and `test.page`.
+
+ **Example**
+ 
+ ```js
+import url from 'url';
+import { mainWindowUrl } from 'testcafe-browser-provider-electron';
+
+fixture `Electron test`
+    .page(mainWindowUrl());
+
+test('Test navigation', async t => {
+    var anotherPageUrl = url.resolve(mainWindowUrl(), 'anotherPage.html');
+    
+    await t.navigateTo(anotherPageUrl);
+});
+ ```
+ 
 ## Author
 Developer Express Inc. (https://devexpress.com)

--- a/legacy/index.js
+++ b/legacy/index.js
@@ -1,0 +1,49 @@
+var Promise     = require('pinkie');
+var ipcRenderer = require('electron').ipcRenderer;
+var Helpers     = require('../lib/helpers');
+var MESSAGES    = require('../lib/messages');
+
+
+function _emitWithResponse (event, data) {
+    return new Promise(function (resolve) {
+        ipcRenderer.once(event + MESSAGES.responsePostfix, (e, data) => {
+            resolve(data);
+        });
+
+        if (data)
+            ipcRenderer.send(event, data);
+        else
+            ipcRenderer.send(event);
+    });
+}
+
+var legacyIPC = {
+    setDialogHandler: function (fn, context) {
+        return _emitWithResponse(MESSAGES.setDialogHandler, [
+            fn && fn.toString() || null,
+            context
+        ]);
+    },
+
+    getDialogHandlerStatus: function () {
+        return _emitWithResponse(MESSAGES.getDialogHandlerStatus);
+    },
+
+    resetDialogHandler: function () {
+        return _emitWithResponse(MESSAGES.resetDialogHandler);
+    },
+
+    getMainMenu: function () {
+        return _emitWithResponse(MESSAGES.getMainMenu);
+    },
+
+    getContextMenu: function () {
+        return _emitWithResponse(MESSAGES.getContextMenu);
+    },
+
+    clickOnMenuItem: function (menuType, menuItemIndex, modifiers) {
+        return _emitWithResponse(MESSAGES.clickOnMenuItem, [menuType, menuItemIndex, modifiers]);
+    }
+};
+
+module.exports = new Helpers(legacyIPC);

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "dedent": "^0.7.0",
     "endpoint-utils": "^1.0.2",
     "mustache": "^2.3.0",
+    "node-ipc": "^9.1.0",
     "os-family": "^1.0.0",
     "pify": "^2.3.0",
     "pinkie": "^2.0.4",

--- a/src/constants.js
+++ b/src/constants.js
@@ -13,6 +13,6 @@ export default {
         'icon', 'sublabel', 'enabled', 'visible', 'checked', 'commandId'
     ],
 
-    testUrlMarker:       'ELECTRON MAIN WINDOW URL',
+    blankPage:           'about:blank',
     testUrlMarkerRegExp: /ELECTRON\s*MAIN\s*WINDOW\s*URL/i
 };

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,15 +1,18 @@
 export default {
-    contextMenuGlobal:       '%testcafe-context-menu%',
-    mainPathEnv:             'TESTCAFE_ELECTRON_MAIN_PATH',
-    testUrlEnv:              'TESTCAFE_ELECTRON_TEST_URL',
     configFileName:          '.testcafe-electron-rc',
     mainMenuType:            'mainMenu',
     contextMenuType:         'contextMenu',
     typeProperty:            '%type%',
     indexProperty:           '%index%',
-    electronStartedMarker:   'testcafe-browser-provider-electron: Electron started',
-    electronErrorMarker:     'testcafe-browser-provider-electron: Error',
     connectionRetryDelay:    300,
     maxConnectionRetryCount: 10,
-    loadingTimeout:          30000
+    loadingTimeout:          3000,
+
+    menuSerializableProperties: [
+        'items', 'groupsMap', 'commandsMap', 'label', 'submenu', 'type', 'role', 'accelerator',
+        'icon', 'sublabel', 'enabled', 'visible', 'checked', 'commandId'
+    ],
+
+    testUrlMarker:       'ELECTRON MAIN WINDOW URL',
+    testUrlMarkerRegExp: /ELECTRON\s*MAIN\s*WINDOW\s*URL/i
 };

--- a/src/constants.js
+++ b/src/constants.js
@@ -6,7 +6,7 @@ export default {
     indexProperty:           '%index%',
     connectionRetryDelay:    300,
     maxConnectionRetryCount: 10,
-    loadingTimeout:          3000,
+    loadingTimeout:          30000,
 
     menuSerializableProperties: [
         'items', 'groupsMap', 'commandsMap', 'label', 'submenu', 'type', 'role', 'accelerator',

--- a/src/errors.js
+++ b/src/errors.js
@@ -1,6 +1,6 @@
 import dedent from 'dedent';
 import { render as renderTemplate } from 'mustache';
-import CONSTANTS from './constants';
+
 
 export default {
     mainUrlWasNotLoaded: dedent `
@@ -12,7 +12,11 @@ export default {
         {{/openedUrls}}
     `,
 
+    expectedDialogDidntAppear: 'Error: An expected Electron dialog didn\'t appear',
+    unexpectedDialogAppeared:  'Error: An unexpected Electron dialog appeared',
+    invalidMenuItemArgument:   'Invalid menu item argument',
+
     render (template, data) {
-        return CONSTANTS.electronErrorMarker + renderTemplate(template, data);
+        return renderTemplate(template, data);
     }
 };

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -1,0 +1,92 @@
+import CONSTANTS from './constants';
+import ERRORS from './errors';
+
+const simplifyMenuItemLabel = label => label.replace(/[\s&]/g, '').toLowerCase();
+
+const MENU_ITEM_INDEX_RE = /\[(\d+)\]$/;
+
+const MODIFIERS_KEYS_MAP = {
+    'shift': 'shiftKey',
+    'ctrl':  'ctrlKey',
+    'alt':   'altKey',
+    'meta':  'metaKey'
+};
+
+function wrapMenu (type, menu, index = []) {
+    if (!menu)
+        return null;
+
+    for (var i = 0; i < menu.items.length; i++) {
+        var currentIndex = index.concat(i);
+        var item         = menu.items[i];
+
+        item[CONSTANTS.typeProperty]  = type;
+        item[CONSTANTS.indexProperty] = currentIndex;
+
+        if (item.submenu)
+            wrapMenu(type, item.submenu, currentIndex);
+    }
+
+    return menu;
+}
+
+function findMenuItem (menu, menuItemPath) {
+    var menuItem = null;
+
+    for (let i = 0; menu && i < menuItemPath.length; i++) {
+        const indexMatch = menuItemPath[i].match(MENU_ITEM_INDEX_RE);
+        const index      = indexMatch ? Number(indexMatch[1]) - 1 : 0;
+        const label      = indexMatch ? menuItemPath[i].replace(MENU_ITEM_INDEX_RE, '') : menuItemPath[i];
+
+        menuItem = menu.items.filter(item => simplifyMenuItemLabel(item.label) === label)[index];
+
+        menu = menuItem && menuItem.submenu || null;
+    }
+
+    return menuItem || null;
+}
+
+function ensureModifiers (srcModifiers = {}) {
+    var result = {};
+
+    Object.keys(MODIFIERS_KEYS_MAP).forEach(mod => result[MODIFIERS_KEYS_MAP[mod]] = !!srcModifiers[mod]);
+
+    return result;
+}
+
+export default class Helpers {
+    constructor (ipc) {
+        this.ipc = ipc;
+    }
+
+    async getMainMenu () {
+        return wrapMenu(CONSTANTS.mainMenuType, await this.ipc.getMainMenu());
+    }
+
+    async getContextMenu () {
+        return wrapMenu(CONSTANTS.contextMenuType, await this.ipc.getContextMenu());
+    }
+
+    async clickOnMenuItem (menuItem, modifiers = {}) {
+        var menuItemSnapshot = typeof menuItem === 'string' ? await this.getMenuItem(menuItem) : menuItem;
+
+        if (!menuItemSnapshot)
+            throw new Error(ERRORS.invalidMenuItemArgument);
+
+        await this.ipc.clickOnMenuItem(menuItemSnapshot[CONSTANTS.typeProperty], menuItemSnapshot[CONSTANTS.indexProperty], ensureModifiers(modifiers));
+    }
+
+    async setElectronDialogHandler (fn, context) {
+        await this.ipc.setDialogHandler(fn, context);
+    }
+
+    async getMenuItem (menuItemSelector) {
+        var menuItemPath = menuItemSelector.split(/\s*>\s*/).map(simplifyMenuItemLabel);
+        var menu         = menuItemPath[0] === 'contextmenu' ? await this.getContextMenu() : await this.getMainMenu();
+
+        if (menuItemPath[0] === 'contextmenu' || menuItemPath[0] === 'mainmenu')
+            menuItemPath.shift();
+
+        return findMenuItem(menu, menuItemPath);
+    }
+}

--- a/src/index.js
+++ b/src/index.js
@@ -1,8 +1,8 @@
 import path from 'path';
 import { statSync } from 'fs';
-import browserTools from 'testcafe-browser-tools';
-import { exec } from 'child_process';
+import { spawn } from 'child_process';
 import Promise from 'pinkie';
+import browserTools from 'testcafe-browser-tools';
 import OS from 'os-family';
 import { getFreePorts } from 'endpoint-utils';
 import NodeDebug from './node-debug';
@@ -10,140 +10,30 @@ import NodeInspect from './node-inspect';
 import isAbsolute from './utils/is-absolute';
 import getConfig from './utils/get-config';
 import getHookCode from './hook';
-import MESSAGES from './messages';
+import { Server as IPCServer } from './ipc';
+import Helpers from './helpers';
+import setupTestCafeMocks from './testcafe-mocks';
 import CONSTANTS from './constants';
+import ERRORS from './errors';
 
-import { ClientFunction } from 'testcafe';
-
-
-const simplifyMenuItemLabel = label => label.replace(/[\s&]/g, '').toLowerCase();
-
-const MENU_ITEM_INDEX_RE = /\[(\d+)\]$/;
-
-const MODIFIERS_KEYS_MAP = {
-    'shift': 'shiftKey',
-    'ctrl':  'ctrlKey',
-    'alt':   'altKey',
-    'meta':  'metaKey'
-};
-
-/* eslint-disable no-undef */
-function terminateElectron () {
-    setTimeout(function () {
-        require('electron').remote.process.exit(0);
-    }, 100);
-
-    return true;
-}
-
-const getMainMenu = ClientFunction(() => {
-    return require('electron').remote.Menu.getApplicationMenu();
-});
-
-const getContextMenu = ClientFunction(() => {
-    return require('electron').remote.getGlobal(contextMenuGlobal);
-}, { dependencies: CONSTANTS });
-
-const doClickOnMenuItem = ClientFunction((menuType, menuItemIndex, modifiers) => {
-    var remote = require('electron').remote;
-    var menu   = null;
-
-    switch (menuType) {
-        case mainMenuType:
-            menu = remote.Menu.getApplicationMenu();
-            break;
-
-        case contextMenuType:
-            menu = remote.getGlobal(contextMenuGlobal);
-            break;
-    }
-
-    if (!menu)
-        return;
-
-    var menuItem = menuItemIndex
-        .reduce((m, i) => m.items[i].submenu || m.items[i], menu);
-
-    menuItem.click(menuItem, require('electron').remote.getCurrentWindow(), modifiers);
-}, { dependencies: CONSTANTS });
-
-const doSetElectronDialogHandler = ClientFunction(serializedHandler => {
-    var { ipcRenderer } = require('electron');
-
-    ipcRenderer.send(setHandler, serializedHandler);
-}, { dependencies: MESSAGES });
-/* eslint-enable no-undef */
-
-const TERMINATE_ELECTRON_SCRIPT = terminateElectron.toString();
+import testRunTracker from 'testcafe/lib/api/test-run-tracker';
 
 function startElectron (config, ports) {
     var cmd            = '';
-    var debugPortsArgs = `--debug-brk=${ports[0]} --inspect-brk=${ports[1]}`;
-    var extraArgs      = config.appArgs ? ' ' + config.appArgs.join(' ') : '';
+    var args           = null;
+    var debugPortsArgs = [`--debug-brk=${ports[0]}`, `--inspect-brk=${ports[1]}`];
+    var extraArgs      = config.appArgs || [];
 
-    if (OS.mac && statSync(config.electronPath).isDirectory())
-        cmd = `open -naW "${config.electronPath}" --args ${debugPortsArgs}${extraArgs}`;
-    else
-        cmd = `"${config.electronPath}" ${debugPortsArgs}${extraArgs}`;
-
-    return new Promise((resolve, reject) => {
-        var electronProcess = exec(cmd, (err, stdout) => {
-            if (!err)
-                return;
-
-            var errorStartIndex = stdout.indexOf(CONSTANTS.electronErrorMarker);
-
-            reject(new Error(stdout.substring(errorStartIndex + CONSTANTS.electronErrorMarker.length)));
-        });
-
-
-        electronProcess.stdout.on('data', data => {
-            if (data.toString().indexOf(CONSTANTS.electronStartedMarker) > -1)
-                resolve();
-        });
-    });
-}
-
-function wrapMenu (type, menu, index = []) {
-    if (!menu)
-        return null;
-
-    for (var i = 0; i < menu.items.length; i++) {
-        var currentIndex = index.concat(i);
-        var item         = menu.items[i];
-
-        item[CONSTANTS.typeProperty]  = type;
-        item[CONSTANTS.indexProperty] = currentIndex;
-
-        if (item.submenu)
-            wrapMenu(type, item.submenu, currentIndex);
+    if (OS.mac && statSync(config.electronPath).isDirectory()) {
+        cmd  = 'open';
+        args = ['-naW', `"${config.electronPath}"`, '--args'].concat(debugPortsArgs, extraArgs);
+    }
+    else {
+        cmd  = config.electronPath;
+        args = debugPortsArgs.concat(extraArgs);
     }
 
-    return menu;
-}
-
-function findMenuItem (menu, menuItemPath) {
-    var menuItem = null;
-
-    for (let i = 0; menu && i < menuItemPath.length; i++) {
-        const indexMatch = menuItemPath[i].match(MENU_ITEM_INDEX_RE);
-        const index      = indexMatch ? Number(indexMatch[1]) - 1 : 0;
-        const label      = indexMatch ? menuItemPath[i].replace(MENU_ITEM_INDEX_RE, '') : menuItemPath[i];
-
-        menuItem = menu.items.filter(item => simplifyMenuItemLabel(item.label) === label)[index];
-
-        menu = menuItem && menuItem.submenu || null;
-    }
-
-    return menuItem || null;
-}
-
-function ensureModifiers (srcModifiers = {}) {
-    var result = {};
-
-    Object.keys(MODIFIERS_KEYS_MAP).forEach(mod => result[MODIFIERS_KEYS_MAP[mod]] = !!srcModifiers[mod]);
-
-    return result;
+    spawn(cmd, args, { stdio: 'ignore' });
 }
 
 async function injectHookCode (client, code) {
@@ -155,16 +45,27 @@ async function injectHookCode (client, code) {
 
 const ElectronBrowserProvider = {
     isMultiBrowser: true,
+    openedBrowsers: {},
+
+    _getBrowserHelpers () {
+        var testRun = testRunTracker.resolveContextTestRun();
+        var id      = testRun.browserConnection.id;
+
+        return ElectronBrowserProvider.openedBrowsers[id].helpers;
+    },
 
     async openBrowser (id, pageUrl, mainPath) {
         if (!isAbsolute(mainPath))
             mainPath = path.join(process.cwd(), mainPath);
 
-        var config = getConfig(mainPath);
+        var config    = getConfig(id, mainPath);
+        var ipcServer = new IPCServer(config);
+
+        await ipcServer.start();
 
         var ports = await getFreePorts(2);
 
-        var electronPromise = startElectron(config, ports);
+        startElectron(config, ports, ipcServer);
 
         var hookCode      = getHookCode(config, pageUrl);
         var debugClient   = new NodeDebug(ports[0]);
@@ -175,11 +76,34 @@ const ElectronBrowserProvider = {
             injectHookCode(inspectClient, hookCode)
         ]);
 
-        await electronPromise;
+        await ipcServer.connect();
+
+        var injectingStatus = await ipcServer.getInjectingStatus();
+
+        if (!injectingStatus.completed) {
+            await ipcServer.terminateProcess();
+
+            ipcServer.stop();
+
+            throw new Error(ERRORS.render(ERRORS.mainUrlWasNotLoaded, {
+                mainWindowUrl: config.mainWindowUrl,
+                openedUrls:    injectingStatus.openedUrls
+            }));
+        }
+
+        this.openedBrowsers[id] = {
+            config:  config,
+            ipc:     ipcServer,
+            helpers: new Helpers(ipcServer)
+        };
     },
 
     async closeBrowser (id) {
-        await this.runInitScript(id, TERMINATE_ELECTRON_SCRIPT);
+        await this.openedBrowsers[id].ipc.terminateProcess();
+
+        this.openedBrowsers[id].ipc.stop();
+
+        delete this.openedBrowsers[id];
     },
 
     async getBrowserList () {
@@ -201,38 +125,40 @@ const ElectronBrowserProvider = {
 
     //Helpers
     async getMainMenu () {
-        return wrapMenu(CONSTANTS.mainMenuType, await getMainMenu());
+        return ElectronBrowserProvider._getBrowserHelpers().getMainMenu();
     },
 
+
     async getContextMenu () {
-        return wrapMenu(CONSTANTS.contextMenuType, await getContextMenu());
+        return ElectronBrowserProvider._getBrowserHelpers().getContextMenu();
     },
 
     async clickOnMenuItem (menuItem, modifiers = {}) {
-        var menuItemSnapshot = typeof menuItem === 'string' ? await ElectronBrowserProvider.getMenuItem(menuItem) : menuItem;
-
-        if (!menuItemSnapshot)
-            throw new Error('Invalid menu item argument');
-
-        await doClickOnMenuItem(menuItemSnapshot[CONSTANTS.typeProperty], menuItemSnapshot[CONSTANTS.indexProperty], ensureModifiers(modifiers));
+        return ElectronBrowserProvider._getBrowserHelpers().clickOnMenuItem(menuItem, modifiers);
     },
 
     async setElectronDialogHandler (fn, context) {
-        await doSetElectronDialogHandler({
-            fn:  fn.toString(),
-            ctx: context
-        });
+        return ElectronBrowserProvider._getBrowserHelpers().setElectronDialogHandler(fn, context);
     },
 
     async getMenuItem (menuItemSelector) {
-        var menuItemPath = menuItemSelector.split(/\s*>\s*/).map(simplifyMenuItemLabel);
-        var menu         = menuItemPath[0] === 'contextmenu' ? await ElectronBrowserProvider.getContextMenu() : await ElectronBrowserProvider.getMainMenu();
+        return ElectronBrowserProvider._getBrowserHelpers().getMainMenu(menuItemSelector);
+    },
 
-        if (menuItemPath[0] === 'contextmenu' || menuItemPath[0] === 'mainmenu')
-            menuItemPath.shift();
+    mainWindowUrl () {
+        var testRun = testRunTracker.resolveContextTestRun();
 
-        return findMenuItem(menu, menuItemPath);
+        if (!testRun)
+            return CONSTANTS.testUrlMarker;
+
+        var id = testRun.browserConnection.id;
+
+        return ElectronBrowserProvider.openedBrowsers[id].config.mainWindowUrl;
     }
+
+
 };
 
 export { ElectronBrowserProvider as default };
+
+setupTestCafeMocks(ElectronBrowserProvider);

--- a/src/index.js
+++ b/src/index.js
@@ -43,6 +43,7 @@ async function injectHookCode (client, code) {
     client.dispose();
 }
 
+
 const ElectronBrowserProvider = {
     isMultiBrowser: true,
     openedBrowsers: {},
@@ -149,7 +150,7 @@ const ElectronBrowserProvider = {
         var testRun = testRunTracker.resolveContextTestRun();
 
         if (!testRun)
-            return CONSTANTS.testUrlMarker;
+            return CONSTANTS.blankPage;
 
         var id = testRun.browserConnection.id;
 

--- a/src/ipc.js
+++ b/src/ipc.js
@@ -1,0 +1,249 @@
+import vm from 'vm';
+import Promise from 'pinkie';
+import { IPC } from 'node-ipc';
+import CONSTANTS from './constants';
+import MESSAGES from './messages';
+
+
+export class Server {
+    constructor (config) {
+        this.id            = config.serverId;
+        this.ipc           = new IPC();
+        this.server        = null;
+        this.socket        = null;
+        this.socketPromise = null;
+        this.injectingStatus = null;
+        this.injectingStatusPromise = null;
+    }
+
+    _emitWithResponse (event, data) {
+        return new Promise(resolve => {
+            this.server.on(event + MESSAGES.responsePostfix, result => {
+                this.server.off(event + MESSAGES.responsePostfix, '*');
+                resolve(result);
+            });
+
+            if (data)
+                this.server.emit(this.socket, event, data);
+            else
+                this.server.emit(this.socket, event);
+        });
+    }
+
+    _startIpcServer () {
+        return new Promise(resolve => {
+            this.ipc.serve(() => resolve(this.ipc.server));
+
+            this.ipc.server.start();
+        });
+    }
+
+    _getIpcSocket () {
+        return new Promise(resolve => this.server.on('connect', resolve));
+    }
+
+    _getInjectingStatusPromise () {
+        return new Promise(resolve => {
+            this.server.on(MESSAGES.getInjectingStatus, data => {
+                this.server.off(MESSAGES.getInjectingStatus, '*');
+                resolve(data);
+            });
+        });
+    }
+
+    async start () {
+        this.ipc.config.id     = this.id;
+        this.ipc.config.silent = true;
+
+        this.server = await this._startIpcServer();
+
+        if (!this.socketPromise)
+            this.socketPromise = this._getIpcSocket();
+
+        return this.server;
+    }
+
+    async connect () {
+        if (this.socket)
+            return;
+
+        if (!this.socketPromise)
+            this.socketPromise = this._getIpcSocket();
+
+        if (!this.injectingStatusPromise)
+            this.injectingStatusPromise = this._getInjectingStatusPromise();
+
+        this.socket = await this.socketPromise;
+    }
+
+    stop () {
+        this.server.stop();
+    }
+
+    async setDialogHandler (fn, context) {
+        return await this._emitWithResponse(MESSAGES.setDialogHandler, [
+            fn && fn.toString() || null,
+            context
+        ]);
+    }
+
+    async getDialogHandlerStatus () {
+        return await this._emitWithResponse(MESSAGES.getDialogHandlerStatus);
+    }
+
+    async resetDialogHandler () {
+        return await this._emitWithResponse(MESSAGES.resetDialogHandler);
+    }
+
+    async getMainMenu () {
+        return await this._emitWithResponse(MESSAGES.getMainMenu);
+    }
+
+    async getContextMenu () {
+        return await this._emitWithResponse(MESSAGES.getContextMenu);
+    }
+
+    async clickOnMenuItem (menuType, menuItemIndex, modifiers) {
+        return await this._emitWithResponse(MESSAGES.clickOnMenuItem, [menuType, menuItemIndex, modifiers]);
+    }
+
+    async getInjectingStatus () {
+        if (this.injectingStatus)
+            return this.injectingStatus;
+
+        if (!this.injectingStatusPromise)
+            this.injectingStatusPromise = this._getInjectingStatusPromise();
+
+        return await this.injectingStatusPromise;
+    }
+
+    async terminateProcess () {
+        return await this._emitWithResponse(MESSAGES.terminateProcess);
+    }
+}
+
+export class Client {
+    constructor (config, { dialogHandler, contextMenuHandler, windowHandler }) {
+        this.id       = config.clientId;
+        this.serverId = config.serverId;
+        this.ipc      = new IPC();
+        this.client   = null;
+
+        this.dialogHandler      = dialogHandler;
+        this.contextMenuHandler = contextMenuHandler;
+        this.windowHandler      = windowHandler;
+    }
+
+    _connectToIpcServer () {
+        return new Promise(resolve => {
+            this.ipc.connectTo(this.serverId, resolve);
+        });
+    }
+
+    _updateDialogHandlerStatus () {
+        if (this.dialogHandler.fn && !this.dialogHandler.handledDialog)
+            this.dialogHandler.hadNoExpectedDialogs = true;
+    }
+
+    _setupHandler (event, handler) {
+        this.client.on(event, async args => {
+            var result = await handler.apply(this, args);
+
+            this.client.emit(event + MESSAGES.responsePostfix, result);
+        });
+
+        require('electron').ipcMain.on(event, async (e, args) => {
+            var result = await handler.apply(this, args);
+
+            e.sender.send(event + MESSAGES.responsePostfix, result);
+        });
+    }
+
+    setDialogHandler (fn, context) {
+        this._updateDialogHandlerStatus();
+
+        this.dialogHandler.handledDialog = false;
+
+        if (!fn) {
+            this.dialogHandler.fn = null;
+            return;
+        }
+
+        this.dialogHandler.fn = vm.runInNewContext(`(${fn})`, context || {});
+    }
+
+    getDialogHandlerStatus () {
+        this._updateDialogHandlerStatus();
+
+        return {
+            hadUnexpectedDialogs: this.dialogHandler.hadUnexpectedDialogs,
+            hadNoExpectedDialogs: this.dialogHandler.hadNoExpectedDialogs
+        };
+    }
+
+    resetDialogHandler () {
+        this.dialogHandler.fn                   = null;
+        this.dialogHandler.handledDialog        = false;
+        this.dialogHandler.hadUnexpectedDialogs = false;
+        this.dialogHandler.hadNoExpectedDialogs = false;
+    }
+
+    getMainMenu () {
+        var menu = require('electron').Menu.getApplicationMenu();
+
+        return JSON.parse(JSON.stringify(menu, CONSTANTS.menuSerializableProperties));
+    }
+
+    getContextMenu () {
+        return JSON.parse(JSON.stringify(this.contextMenuHandler.menu, CONSTANTS.menuSerializableProperties));
+    }
+
+    clickOnMenuItem (menuType, menuItemIndex, modifiers) {
+        var menu = null;
+
+        switch (menuType) {
+            case CONSTANTS.mainMenuType:
+                menu = require('electron').Menu.getApplicationMenu();
+                break;
+
+            case CONSTANTS.contextMenuType:
+                menu = this.contextMenuHandler.menu;
+                break;
+        }
+
+        if (!menu)
+            return;
+
+        var menuItem = menuItemIndex
+            .reduce((m, i) => m.items[i].submenu || m.items[i], menu);
+
+
+        menuItem.click(menuItem, require('electron').BrowserWindow.getFocusedWindow(), modifiers);
+    }
+
+    sendInjectingStatus (status) {
+        this.client.emit(MESSAGES.getInjectingStatus, status);
+    }
+
+    terminateProcess () {
+        setTimeout(() => process.exit(0), 0);
+    }
+
+    async connect () {
+        this.ipc.config.id     = this.id;
+        this.ipc.config.silent = true;
+
+        await this._connectToIpcServer();
+
+        this.client = this.ipc.of[this.serverId];
+
+        this._setupHandler(MESSAGES.setDialogHandler, this.setDialogHandler);
+        this._setupHandler(MESSAGES.getDialogHandlerStatus, this.getDialogHandlerStatus);
+        this._setupHandler(MESSAGES.resetDialogHandler, this.resetDialogHandler);
+        this._setupHandler(MESSAGES.getMainMenu, this.getMainMenu);
+        this._setupHandler(MESSAGES.getContextMenu, this.getContextMenu);
+        this._setupHandler(MESSAGES.clickOnMenuItem, this.clickOnMenuItem);
+        this._setupHandler(MESSAGES.terminateProcess, this.terminateProcess);
+    }
+
+}

--- a/src/messages.js
+++ b/src/messages.js
@@ -1,3 +1,13 @@
 export default {
-    setHandler: '%testcafe-set-handler%'
+    responsePostfix: '-response',
+
+    setDialogHandler:       'set-dialog-handler',
+    getDialogHandlerStatus: 'get-dialog-handler-status',
+    resetDialogHandler:     'reset-dialog-handler',
+    getMainMenu:            'get-main-menu',
+    getContextMenu:         'get-context-menu',
+    clickOnMenuItem:        'click-on-menu-item',
+
+    getInjectingStatus: 'get-injecting-status',
+    terminateProcess:   'terminate-process'
 };

--- a/src/testcafe-mocks.js
+++ b/src/testcafe-mocks.js
@@ -1,0 +1,107 @@
+import { embeddingUtils } from 'testcafe';
+import { TestRun as LegacyTestRun } from 'testcafe-legacy-api';
+import { Proxy as HammerheadProxy } from 'testcafe-hammerhead';
+import { UncaughtErrorInTestCode } from 'testcafe/lib/errors/test-run';
+import { uncaughtJSError } from 'testcafe-legacy-api/lib/test-run-error/type';
+import CONSTANTS from './constants';
+import ERRORS from './errors';
+
+
+function mockTestRun (provider) {
+    var originalStart = embeddingUtils.TestRun.prototype.start;
+
+    embeddingUtils.TestRun.prototype.start = function () {
+        var id = this.browserConnection.id;
+
+        if (!provider.openedBrowsers[id])
+            return originalStart.call(this);
+
+        var testRun          = this;
+        var ipc              = provider.openedBrowsers[id].ipc;
+        var beforeFnName     = ['beforeFn', 'beforeEachFn', 'fn'].filter(fn => this.test[fn])[0];
+        var originalBeforeFn = this.test[beforeFnName];
+
+        this.test[beforeFnName] = async function (...args) {
+            await ipc.resetDialogHandler();
+
+            return originalBeforeFn.apply(this, args);
+        };
+
+        var afterFnName     = ['afterEachFn', 'afterFn', 'fn'].filter(fn => this.test[fn])[0];
+        var originalAfterFn = this.test[afterFnName];
+
+        this.test[afterFnName] = async function (...args) {
+            var result       = await originalAfterFn.apply(this, args);
+            var dialogStatus = await ipc.getDialogHandlerStatus();
+
+            if (dialogStatus.hadUnexpectedDialogs)
+                testRun.addError(new UncaughtErrorInTestCode(ERRORS.unexpectedDialogAppeared));
+
+            if (dialogStatus.hadNoExpectedDialogs)
+                testRun.addError(new UncaughtErrorInTestCode(ERRORS.expectedDialogDidntAppear));
+
+            return result;
+        };
+
+        return originalStart.call(this);
+    };
+}
+
+function mockLegacyTestRun (provider) {
+    var originalEmit = LegacyTestRun.prototype.emit;
+
+    LegacyTestRun.prototype.emit = function (...args) {
+        var id = this.browserConnection.id;
+
+        if (!provider.openedBrowsers[id])
+            return originalEmit.apply(this, args);
+
+        var ipc = provider.openedBrowsers[id].ipc;
+
+        if (args[0] === 'start') {
+            ipc.resetDialogHandler();
+
+            return originalEmit.apply(this, args);
+        }
+        else if (args[0] === 'done') {
+            ipc
+                .getDialogHandlerStatus()
+                .then(async dialogStatus => {
+                    if (dialogStatus.hadUnexpectedDialogs)
+                        await this._addError({ type: uncaughtJSError, scriptErr: ERRORS.unexpectedDialogAppeared });
+
+                    if (dialogStatus.hadNoExpectedDialogs)
+                        await this._addError({ type: uncaughtJSError, scriptErr: ERRORS.expectedDialogDidntAppear });
+
+                    originalEmit.apply(this, args);
+                });
+
+            return !!this.listeners(args[0]).length;
+        }
+
+        return originalEmit.apply(this, args);
+    };
+}
+
+function mockProxy (provider) {
+    var originalOpenSession = HammerheadProxy.prototype.openSession;
+
+    HammerheadProxy.prototype.openSession = function (...args) {
+        if (args[1].browserConnection.browserInfo.providerName !== 'electron' || !args[0] && args[0] !== 'about:blank' && !CONSTANTS.testUrlMarkerRegExp.test(args[0]))
+            return originalOpenSession.apply(this, args);
+
+        var id            = args[1].browserConnection.id;
+        var mainWindowUrl = provider.openedBrowsers[id].config.mainWindowUrl;
+
+        args[0]              = mainWindowUrl;
+        args[1].test.pageUrl = mainWindowUrl;
+
+        return originalOpenSession.apply(this, args);
+    };
+}
+
+export default function (provider) {
+    mockProxy(provider);
+    mockTestRun(provider);
+    mockLegacyTestRun(provider);
+}

--- a/src/utils/get-config.js
+++ b/src/utils/get-config.js
@@ -7,7 +7,7 @@ import CONSTANTS from '../constants';
 
 const PROTOCOL_RE = /^([\w-]+?)(?=\:\/\/)/;
 
-export default function (mainPath) {
+export default function (id, mainPath) {
     if (statSync(mainPath).isDirectory())
         mainPath = path.join(mainPath, CONSTANTS.configFileName);
 
@@ -34,6 +34,9 @@ export default function (mainPath) {
 
     if (config.mainWindowUrl.indexOf('file:') === 0 || !PROTOCOL_RE.test(config.mainWindowUrl))
         config.mainWindowUrl = resolveFileUrl(mainDir, config.mainWindowUrl);
+
+    config.serverId = 'testcafe-electron-server-' + id;
+    config.clientId = 'testcafe-electron-client-' + id;
 
     return config;
 }

--- a/test/fixtures/dialog-test.js
+++ b/test/fixtures/dialog-test.js
@@ -1,10 +1,9 @@
-import { testPage } from '../config';
 import { ClientFunction } from 'testcafe';
 import { setElectronDialogHandler, clickOnMenuItem } from 'testcafe-browser-provider-electron';
+import shouldHaveError from '../helpers/should-have-error';
 
 
-fixture `Dialog`
-    .page(testPage);
+fixture `Dialog`;
 
 const checkDialogHandled = ClientFunction(() => window.dialogResult);
 
@@ -14,4 +13,20 @@ test('Should handle Open Dialog', async t => {
     await clickOnMenuItem('Test > Dialog');
 
     await t.expect(checkDialogHandled()).eql('open-dialog handled');
+});
+
+test('Should throw an Error if there was an unexpected dialog', async t => {
+    shouldHaveError(error => error.errMsg === 'Error: An unexpected Electron dialog appeared');
+
+    await clickOnMenuItem('Test > Dialog');
+
+    await t.wait(3000);
+});
+
+test('Should throw an Error if there was no expected dialog', async t => {
+    shouldHaveError(error => error.errMsg === 'Error: An expected Electron dialog didn\'t appear');
+
+    await setElectronDialogHandler(type => type + ' handled');
+
+    await t.wait(3000);
 });

--- a/test/fixtures/legacy.test.js
+++ b/test/fixtures/legacy.test.js
@@ -1,0 +1,43 @@
+/*eslint-disable*/
+"@fixture Legacy Dialog";
+"@page Electron Main Window URL";
+
+"@test"["Legacy Dialog Test"] = {
+    "Test": function () {
+        act.waitFor(function (cb) {
+            var electronProvider = require('../../legacy');
+
+            electronProvider
+                .setElectronDialogHandler(function (type) {return type + ' handled'})
+                .then(function () { return electronProvider.clickOnMenuItem('Test > Dialog') })
+                .then(cb);
+        });
+    },
+    "Assert": function () {
+        eq(window.dialogResult, 'open-dialog handled')
+    }
+};
+
+// "@test"["Legacy Unexpected Dialog Test"] = {
+//     "Test": function () {
+//         act.waitFor(function (cb) {
+//             var electronProvider = require('../../legacy');
+//
+//             electronProvider.clickOnMenuItem('Test > Dialog')
+//                 .then(cb);
+//         })
+//     }
+// };
+//
+// "@test"["Legacy No Expected Dialog Test"] = {
+//     "Test": function () {
+//         act.waitFor(function (cb) {
+//             var electronProvider = require('../../legacy');
+//
+//             electronProvider
+//                 .setElectronDialogHandler(function (type) {return type + ' handled'})
+//                 .then(cb);
+//         })
+//     }
+// };
+

--- a/test/fixtures/menu-test.js
+++ b/test/fixtures/menu-test.js
@@ -1,15 +1,15 @@
-import { testPage } from '../config';
 import { ClientFunction } from 'testcafe';
-import { clickOnMenuItem } from 'testcafe-browser-provider-electron';
-
+import { clickOnMenuItem, mainWindowUrl } from 'testcafe-browser-provider-electron';
 
 fixture `Menu`
-    .page(testPage);
+    .page(mainWindowUrl());
 
 const checkMainMenuClicked    = ClientFunction(() => window.mainMenuClicked);
 const checkContextMenuClicked = ClientFunction(() => window.contextMenuClicked);
 
 test('Should click on main menu', async t => {
+    await t.wait(1000);
+
     await clickOnMenuItem('Main menu > Test > Click');
 
     await t.expect(checkMainMenuClicked()).ok();

--- a/test/fixtures/page-test.js
+++ b/test/fixtures/page-test.js
@@ -1,8 +1,4 @@
-import { testPage } from '../config';
-
-
-fixture `Electron page`
-    .page(testPage);
+fixture `Electron page`;
 
 test('Check page content', async t => {
     var header = await t.eval(() => document.querySelector('body > h1').textContent);

--- a/test/fixtures/resize-test.js
+++ b/test/fixtures/resize-test.js
@@ -1,9 +1,4 @@
-import { testPage } from '../config';
-
-
-fixture `Resize`
-    .page(testPage);
-
+fixture `Resize`;
 
 test('Resize test', async t => {
     await t.resizeWindow(800, 600);

--- a/test/fixtures/screenshot-test.js
+++ b/test/fixtures/screenshot-test.js
@@ -1,11 +1,8 @@
 import path from 'path';
 import { statSync } from 'fs';
 import { tmpNameSync as getTempFileName } from 'tmp';
-import { testPage } from '../config';
 
-
-fixture `Screenshot`
-    .page(testPage);
+fixture `Screenshot`;
 
 test('Take screenshot', async t => {
     var screenshotName = getTempFileName({ template: 'screenshot-XXXXXX.png' });

--- a/test/helpers/should-have-error.js
+++ b/test/helpers/should-have-error.js
@@ -1,0 +1,38 @@
+import TestRun from 'testcafe/lib/test-run';
+import { UncaughtErrorInTestCode } from 'testcafe/lib/errors/test-run';
+import testRunTracker from 'testcafe/lib/api/test-run-tracker';
+
+
+var originalAddError = TestRun.prototype.addError;
+
+TestRun.prototype.addError = function (err, screenshotPath) {
+    var predicate = this['%addErrorPredicate%'];
+
+    var errorList = err.items ? err.items : [err];
+
+    for (const error of errorList) {
+        if (predicate && predicate(error)) {
+            this['%addErrorPredicatePassed%'] = true;
+            return;
+        }
+    }
+
+    originalAddError.call(this, err, screenshotPath);
+};
+
+var originalEmit = TestRun.prototype.emit;
+
+TestRun.prototype.emit = function (...args) {
+    if (args[0] === 'done') {
+        if (this['%addErrorPredicate%'] && !this['%addErrorPredicatePassed%'])
+            this.addError(new UncaughtErrorInTestCode('AssertionError: The expected error didn\'t appear', ''));
+    }
+
+    return originalEmit.apply(this, args);
+};
+
+export default function (predicate) {
+    var testRun = testRunTracker.resolveContextTestRun();
+
+    testRun['%addErrorPredicate%'] = predicate;
+}


### PR DESCRIPTION
### Changelog
 * If a Electron dialog handler was set, but no dialogs were raised, test will fail. Also test will fail if a diallog appears and there is no handler.

 * Helper `mainWIndowUrl` returns `mainWindowUrl` from config inside test context.

 * `page` declaration can be skipped, or the `mainWindowUrl` helper can be used. In legacy tests a special string `Electron Main Window URL`  can be used (number of spaces and letter-case can be varied)

 * Helpers can be used in legacy tests. Require them from `testcafe-browser-provider-electron/legacy`.

\cc @AlexanderMoskovkin @kirovboris 
