### PR TITLE
Bump Electron to '^7.1.2'

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "gulp-babel": "^7.0.0",
     "gulp-eslint": "^3.0.1",
     "publish-please": "^5.4.3",
-    "testcafe": "1.4.0",
+    "testcafe": "*",
     "tmp": "0.0.28"
   },
   "types": "./ts-defs/index.d.ts"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "testcafe-browser-provider-electron",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "description": "TestCafe browser provider plugin for testing applications built with Electron.",
   "repository": "https://github.com/DevExpress/testcafe-browser-provider-electron",
   "homepage": "https://github.com/DevExpress/testcafe-browser-provider-electron",
@@ -51,7 +51,7 @@
     "babel-plugin-transform-runtime": "^6.23.0",
     "babel-preset-env": "^1.6.0",
     "del": "^2.0.0",
-    "electron": "^6.0.0",
+    "electron": "^7.1.2",
     "gulp": "^4.0.0",
     "gulp-babel": "^7.0.0",
     "gulp-eslint": "^3.0.1",

--- a/src/index.js
+++ b/src/index.js
@@ -24,7 +24,7 @@ function startElectron (config, ports) {
 
     if (OS.mac && statSync(config.electronPath).isDirectory()) {
         cmd  = 'open';
-        args = ['-naW', `"${config.electronPath}"`, '--args'].concat(debugPortsArgs, extraArgs);
+        args = ['-nW', '-a', config.electronPath, '--args'].concat(debugPortsArgs, extraArgs);
     }
     else {
         cmd  = config.electronPath;

--- a/src/injectable/electron-mocks.js
+++ b/src/injectable/electron-mocks.js
@@ -61,11 +61,11 @@ module.exports = function install (config, testPageUrl) {
     var WebContents;
 
     if ( process.atomBinding ) {
-        // < electron 6
+        // < Electron 6
         WebContents = process.atomBinding('web_contents').WebContents;
     }
     else {
-        // electron 6+
+        // >= Electron 6
         WebContents = process.electronBinding('web_contents').WebContents;
     }
 

--- a/src/injectable/electron-mocks.js
+++ b/src/injectable/electron-mocks.js
@@ -61,11 +61,11 @@ module.exports = function install (config, testPageUrl) {
     var WebContents;
 
     if ( process.atomBinding ) {
-        // < Electron 6
+        // NOTE: < Electron 6
         WebContents = process.atomBinding('web_contents').WebContents;
     }
     else {
-        // >= Electron 6
+        // NOTE: >= Electron 6
         WebContents = process.electronBinding('web_contents').WebContents;
     }
 

--- a/src/injectable/index.js
+++ b/src/injectable/index.js
@@ -6,12 +6,12 @@ module.exports = function (config, testPageUrl) {
     var origModuleLoad = Module._load;
 
     Module._load = function (...args) {
-        const isMain               = args[2];
-        const isDefaultElectronApp = isMain && args[0].endsWith(
-            'electron' + sep + 'dist' + sep + 'resources' + sep + 'default_app.asar' + sep + 'main.js'
-        );
+        const isMain                     = args[2];
+        const isNotBrowserInitMainModule = isMain &&
+            args[0] !== 'electron/js2c/browser_init' && // >= Electron v7.0.0
+            !args[0].endsWith('electron.asar' + sep + 'browser' + sep + 'init.js'); // <= Electron v6.1.5
 
-        if (isDefaultElectronApp) {
+        if (isNotBrowserInitMainModule) {
             if (config.appPath) {
                 config.appEntryPoint = require.resolve(config.appPath);
 

--- a/src/injectable/index.js
+++ b/src/injectable/index.js
@@ -4,7 +4,10 @@ module.exports = function (config, testPageUrl) {
     var origModuleLoad = Module._load;
 
     Module._load = function (...args) {
-        if (args[2]) {
+        const isMain               = args[2];
+        const isDefaultElectronApp = isMain && args[0].endsWith('electron\\dist\\resources\\default_app.asar\\main.js');
+
+        if (isDefaultElectronApp) {
             if (config.appPath) {
                 config.appEntryPoint = require.resolve(config.appPath);
 

--- a/src/injectable/index.js
+++ b/src/injectable/index.js
@@ -1,5 +1,15 @@
 import { sep } from 'path';
 
+
+const ELECTRON_BROWSER_INIT_PATHS = [
+    'electron/js2c/browser_init', // NOTE: >= Electron v7.0.0
+    ['electron.asar', 'browser', 'init.js'].join(sep) // NOTE: <= Electron v6.1.5
+];
+
+function isBrowserInitModule (path) {
+    return ELECTRON_BROWSER_INIT_PATHS.some(initPath => path.endsWith(initPath));
+}
+
 module.exports = function (config, testPageUrl) {
     var Module = require('module');
 
@@ -7,9 +17,7 @@ module.exports = function (config, testPageUrl) {
 
     Module._load = function (...args) {
         const isMain                     = args[2];
-        const isNotBrowserInitMainModule = isMain &&
-            args[0] !== 'electron/js2c/browser_init' && // >= Electron v7.0.0
-            !args[0].endsWith('electron.asar' + sep + 'browser' + sep + 'init.js'); // <= Electron v6.1.5
+        const isNotBrowserInitMainModule = isMain && !isBrowserInitModule(args[0]);
 
         if (isNotBrowserInitMainModule) {
             if (config.appPath) {

--- a/src/injectable/index.js
+++ b/src/injectable/index.js
@@ -1,3 +1,5 @@
+import { sep } from 'path';
+
 module.exports = function (config, testPageUrl) {
     var Module = require('module');
 
@@ -5,7 +7,9 @@ module.exports = function (config, testPageUrl) {
 
     Module._load = function (...args) {
         const isMain               = args[2];
-        const isDefaultElectronApp = isMain && args[0].endsWith('electron\\dist\\resources\\default_app.asar\\main.js');
+        const isDefaultElectronApp = isMain && args[0].endsWith(
+            'electron' + sep + 'dist' + sep + 'resources' + sep + 'default_app.asar' + sep + 'main.js'
+        );
 
         if (isDefaultElectronApp) {
             if (config.appPath) {

--- a/src/node-inspect.js
+++ b/src/node-inspect.js
@@ -31,7 +31,9 @@ export default class NodeInspect {
     }
 
     async _setupRemoteInterface () {
-        this.client.Debugger.enable();
+        this.client.Debugger.enable().then(async () => {
+            return this.client.Debugger.setBreakpointByUrl({ lineNumber: 16, urlRegex: '\\main\\run_main_module\.js|internal/main/run_main_module\.js' });
+        });
 
         var pausedEvent = promisifyEvent(this.client, 'Debugger.paused');
 

--- a/src/node-inspect.js
+++ b/src/node-inspect.js
@@ -32,7 +32,7 @@ export default class NodeInspect {
 
     async _setupRemoteInterface () {
         this.client.Debugger.enable().then(async () => {
-            return this.client.Debugger.setBreakpointByUrl({ lineNumber: 16, urlRegex: '\\main\\run_main_module\.js|internal/main/run_main_module\.js' });
+            return this.client.Debugger.setBreakpointByUrl({ lineNumber: 16, url: 'internal/main/run_main_module\.js' });
         });
 
         var pausedEvent = promisifyEvent(this.client, 'Debugger.paused');

--- a/templates/hook.js.mustache
+++ b/templates/hook.js.mustache
@@ -1,4 +1,3 @@
 (function () {
-    require({{{INJECTABLE_PATH}}})({{{CONFIG}}}, {{{TEST_PAGE_URL}}})
+    require('module')._load({{{INJECTABLE_PATH}}})({{{CONFIG}}}, {{{TEST_PAGE_URL}}})
 })();
-


### PR DESCRIPTION
Fix https://github.com/DevExpress/testcafe-browser-provider-electron/issues/50
part of https://github.com/DevExpress/testcafe-browser-provider-electron/issues/37

### Changes
1. Bump Electron to '^7.1.2'. Inject point fix.
2. Fix macOS `open` options (https://github.com/DevExpress/testcafe-browser-provider-electron/issues/37, thank you, @joshuef).

### Checked environments (`npm run test`)
Windows 10 / Ubuntu 18.04.3 LTS / macOS Catalina ([cannot resize Electron](https://github.com/DevExpress/testcafe-browser-provider-electron/issues/52), it can be reproduced with master branch):
`electron@3.1.13`
`electron@4.2.12`
`electron@5.0.12`
`electron@6.1.5`
`electron@7.1.2`
