### PR TITLE
Allow debugging the stdout of the electron main process

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   "dependencies": {
     "babel-runtime": "^6.25.0",
     "chrome-remote-interface": "^0.27.0",
+    "debug": "4.1.1",
     "dedent": "^0.7.0",
     "endpoint-utils": "^1.0.2",
     "lodash": "^4.17.4",

--- a/src/index.js
+++ b/src/index.js
@@ -31,7 +31,7 @@ function startElectron (config, ports) {
         args = debugPortsArgs.concat(extraArgs);
     }
 
-    spawn(cmd, args, { stdio: 'ignore' });
+    spawn(cmd, args, { stdio: process.env.DEBUG ? 'inherit' : 'ignore' });
 }
 
 async function injectHookCode (client, code) {

--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,7 @@ import { statSync } from 'fs';
 import { spawn } from 'child_process';
 import Promise from 'pinkie';
 import OS from 'os-family';
+import debug from 'debug';
 import { getFreePorts } from 'endpoint-utils';
 import NodeDebug from './node-debug';
 import NodeInspect from './node-inspect';
@@ -15,6 +16,9 @@ import ERRORS from './errors';
 
 import testRunTracker from 'testcafe/lib/api/test-run-tracker';
 
+const DEBUG_LOGGER = debug('testcafe:electron');
+const STDOUT_LOGGER = DEBUG_LOGGER.extend('spawn:stdout');
+const STDERR_LOGGER = DEBUG_LOGGER.extend('spawn:stderr')
 
 function startElectron (config, ports) {
     var cmd            = '';
@@ -31,7 +35,14 @@ function startElectron (config, ports) {
         args = debugPortsArgs.concat(extraArgs);
     }
 
-    spawn(cmd, args, { stdio: process.env.DEBUG ? 'inherit' : 'ignore' });
+    var proc = spawn(cmd, args, { stdio: ['ignore', 'pipe', 'pipe'] });
+
+    proc.stdout.on('data', (buf) => {
+        STDOUT_LOGGER(buf.toString())
+    })
+    proc.stderr.on('data', (buf) => {
+        STDERR_LOGGER(buf.toString())
+    })
 }
 
 async function injectHookCode (client, code) {

--- a/src/index.js
+++ b/src/index.js
@@ -38,12 +38,8 @@ function startElectron (config, ports) {
 
     var proc = spawn(cmd, args, { stdio: ['ignore', 'pipe', 'pipe'] });
 
-    proc.stdout.on('data', (buf) => {
-        STDOUT_LOGGER(lodash.trimEnd(String(buf), '\n'));
-    });
-    proc.stderr.on('data', (buf) => {
-        STDERR_LOGGER(lodash.trimEnd(String(buf), '\n'));
-    });
+    proc.stdout.on('data', buf => STDOUT_LOGGER(lodash.trimEnd(String(buf), '\n')));
+    proc.stderr.on('data', buf => STDERR_LOGGER(lodash.trimEnd(String(buf), '\n')));
 }
 
 async function injectHookCode (client, code) {

--- a/src/index.js
+++ b/src/index.js
@@ -16,7 +16,7 @@ import ERRORS from './errors';
 
 import testRunTracker from 'testcafe/lib/api/test-run-tracker';
 
-const DEBUG_LOGGER = debug('testcafe:electron');
+const DEBUG_LOGGER = debug('testcafe:browser-provider-electron');
 const STDOUT_LOGGER = DEBUG_LOGGER.extend('spawn:stdout');
 const STDERR_LOGGER = DEBUG_LOGGER.extend('spawn:stderr');
 

--- a/src/index.js
+++ b/src/index.js
@@ -38,10 +38,18 @@ function startElectron (config, ports) {
     var proc = spawn(cmd, args, { stdio: ['ignore', 'pipe', 'pipe'] });
 
     proc.stdout.on('data', (buf) => {
-        STDOUT_LOGGER(buf.toString().trim());
+        var str = String(buf);
+        if (str[str.length - 1] === '\n') {
+            str = str.slice(0, str.length - 1);
+        }
+        STDOUT_LOGGER(str);
     });
     proc.stderr.on('data', (buf) => {
-        STDERR_LOGGER(buf.toString().trim());
+        var str = String(buf);
+        if (str[str.length - 1] === '\n') {
+            str = str.slice(0, str.length - 1);
+        }
+        STDERR_LOGGER(str);
     });
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -18,7 +18,7 @@ import testRunTracker from 'testcafe/lib/api/test-run-tracker';
 
 const DEBUG_LOGGER = debug('testcafe:electron');
 const STDOUT_LOGGER = DEBUG_LOGGER.extend('spawn:stdout');
-const STDERR_LOGGER = DEBUG_LOGGER.extend('spawn:stderr')
+const STDERR_LOGGER = DEBUG_LOGGER.extend('spawn:stderr');
 
 function startElectron (config, ports) {
     var cmd            = '';
@@ -38,11 +38,11 @@ function startElectron (config, ports) {
     var proc = spawn(cmd, args, { stdio: ['ignore', 'pipe', 'pipe'] });
 
     proc.stdout.on('data', (buf) => {
-        STDOUT_LOGGER(buf.toString().trim())
-    })
+        STDOUT_LOGGER(buf.toString().trim());
+    });
     proc.stderr.on('data', (buf) => {
-        STDERR_LOGGER(buf.toString().trim())
-    })
+        STDERR_LOGGER(buf.toString().trim());
+    });
 }
 
 async function injectHookCode (client, code) {

--- a/src/index.js
+++ b/src/index.js
@@ -38,10 +38,10 @@ function startElectron (config, ports) {
     var proc = spawn(cmd, args, { stdio: ['ignore', 'pipe', 'pipe'] });
 
     proc.stdout.on('data', (buf) => {
-        STDOUT_LOGGER(buf.toString())
+        STDOUT_LOGGER(buf.toString().trim())
     })
     proc.stderr.on('data', (buf) => {
-        STDERR_LOGGER(buf.toString())
+        STDERR_LOGGER(buf.toString().trim())
     })
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -4,6 +4,7 @@ import { spawn } from 'child_process';
 import Promise from 'pinkie';
 import OS from 'os-family';
 import debug from 'debug';
+import lodash from 'lodash';
 import { getFreePorts } from 'endpoint-utils';
 import NodeDebug from './node-debug';
 import NodeInspect from './node-inspect';
@@ -38,18 +39,10 @@ function startElectron (config, ports) {
     var proc = spawn(cmd, args, { stdio: ['ignore', 'pipe', 'pipe'] });
 
     proc.stdout.on('data', (buf) => {
-        var str = String(buf);
-        if (str[str.length - 1] === '\n') {
-            str = str.slice(0, str.length - 1);
-        }
-        STDOUT_LOGGER(str);
+        STDOUT_LOGGER(lodash.trimEnd(String(buf), '\n'));
     });
     proc.stderr.on('data', (buf) => {
-        var str = String(buf);
-        if (str[str.length - 1] === '\n') {
-            str = str.slice(0, str.length - 1);
-        }
-        STDERR_LOGGER(str);
+        STDERR_LOGGER(lodash.trimEnd(String(buf), '\n'));
     });
 }
 


### PR DESCRIPTION
When using `testcafe` to run tests against an electron app we do not have any visibility into the behavior of the electron main process.

If anything writes to stdout or stderr its ignored by default.