### PR TITLE
Fix timing issue with electron@8

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "babel-plugin-transform-runtime": "^6.23.0",
     "babel-preset-env": "^1.6.0",
     "del": "^2.0.0",
-    "electron": "^7.1.2",
+    "electron": "^8.2.3",
     "gulp": "^4.0.0",
     "gulp-babel": "^7.0.0",
     "gulp-eslint": "^3.0.1",

--- a/src/injectable/electron-mocks.js
+++ b/src/injectable/electron-mocks.js
@@ -114,7 +114,7 @@ module.exports = function install (config, testPageUrl) {
 
     WebContents.prototype.loadURL = function (url, options) {
         startLoadingTimeout(config.mainWindowUrl);
-        
+
         if (ELECTRON_VERSION >= ELECTRON_VERSION_WITH_ASYNC_LOAD_URL)
             return ipcConnectionPromise.then(() => loadUrl(this, url, options));
 

--- a/src/injectable/electron-mocks.js
+++ b/src/injectable/electron-mocks.js
@@ -2,6 +2,10 @@ import { Client } from '../ipc';
 import resolveFileUrl from '../utils/resolve-file-url';
 import CONSTANTS from '../constants';
 
+const ELECTRON_VERSION  = process.versions.electron && Number(process.versions.electron.split('.')[0]);
+
+const ELECTRON_VERSION_WITH_ASYNC_LOAD_URL = 5;
+
 const URL_QUERY_RE      = /\?.*$/;
 const NAVIGATION_EVENTS = ['will-navigate', 'did-navigate'];
 
@@ -55,6 +59,7 @@ module.exports = function install (config, testPageUrl) {
     ipc = new Client(config, { dialogHandler, contextMenuHandler, windowHandler });
 
     const ipcConnectionPromise = ipc.connect();
+    
     var { Menu, dialog, app } = require('electron');
 
     var WebContents;
@@ -81,9 +86,7 @@ module.exports = function install (config, testPageUrl) {
         return url.indexOf('file:') === 0;
     }
 
-    WebContents.prototype.loadURL = async function (url, options) {
-        startLoadingTimeout(config.mainWindowUrl);
-        await ipcConnectionPromise;
+    function loadUrl (webContext, url, options) {
         let testUrl = stripQuery(url);
 
         if (isFileProtocol(url))
@@ -103,10 +106,19 @@ module.exports = function install (config, testPageUrl) {
             windowHandler.window = this;
 
             if (config.openDevTools)
-                this.openDevTools();
+                webContext.openDevTools();
         }
 
-        return origLoadURL.call(this, url, options);
+        return origLoadURL.call(webContext, url, options);
+    }
+
+    WebContents.prototype.loadURL = function (url, options) {
+        startLoadingTimeout(config.mainWindowUrl);
+        
+        if (ELECTRON_VERSION >= ELECTRON_VERSION_WITH_ASYNC_LOAD_URL)
+            return ipcConnectionPromise.then(() => loadUrl(this, url, options));
+
+        return loadUrl(this, url, options);
     };
 
     app.getAppPath = function () {

--- a/src/injectable/electron-mocks.js
+++ b/src/injectable/electron-mocks.js
@@ -54,8 +54,7 @@ function handleDialog (type, args) {
 module.exports = function install (config, testPageUrl) {
     ipc = new Client(config, { dialogHandler, contextMenuHandler, windowHandler });
 
-    ipc.connect();
-
+    const ipcConnectionPromise = ipc.connect();
     var { Menu, dialog, app } = require('electron');
 
     var WebContents;
@@ -82,9 +81,9 @@ module.exports = function install (config, testPageUrl) {
         return url.indexOf('file:') === 0;
     }
 
-    WebContents.prototype.loadURL = function (url, options) {
+    WebContents.prototype.loadURL = async function (url, options) {
         startLoadingTimeout(config.mainWindowUrl);
-
+        await ipcConnectionPromise;
         let testUrl = stripQuery(url);
 
         if (isFileProtocol(url))


### PR DESCRIPTION
Fix issue #64 
`ipc.connect()` is an async function, I don't really know why it is working with electron@7, but it is definitely not a good idea to expect client to be ready to send messages without waiting `connec()`
