### PR TITLE
Support Electron 11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ node_js:
 notifications:
   email: false
 
-dist: trusty
+dist: focal
 sudo: false
 
 addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,9 @@ notifications:
 dist: focal
 sudo: false
 
+services:
+  - xvfb
+
 addons:
   apt:
     packages:
@@ -15,7 +18,6 @@ addons:
 
 before_script:
   - "export DISPLAY=:99.0"
-  - "sh -e /etc/init.d/xvfb start"
   - sleep 3
   - fluxbox >/dev/null 2>&1 &
   - stty cols 80

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "babel-plugin-transform-runtime": "^6.23.0",
     "babel-preset-env": "^1.6.0",
     "del": "^2.0.0",
-    "electron": "^8.2.3",
+    "electron": "^11.0.3",
     "gulp": "^4.0.0",
     "gulp-babel": "^7.0.0",
     "gulp-eslint": "^3.0.1",

--- a/src/injectable/electron-mocks.js
+++ b/src/injectable/electron-mocks.js
@@ -121,8 +121,10 @@ module.exports = function install (config, testPageUrl) {
         return loadUrl(this, url, options);
     }
 
-    // NOTE: Electron 11 has no loadURL method in the WebContents prototype,
-    // so we update it in the WebContents.prototype._init method due to the Electron 11 logic. (GH-73)
+    // NOTE: Electron 11 has no loadURL method in the WebContents prototype.
+    // We imitate the native behavior (https://github.com/electron/electron/pull/24325/files#diff-f6ca6a11b1d9a20b2f71e91a51c06f4956adb0eec9f07ac0705190f77c257211R437,
+    // https://github.com/electron/electron/blob/v11.0.3/lib/browser/api/web-contents.ts#L472)
+    // and rewrite it as soon it became available. (GH-73)
     if (WebContents.prototype._init) {
         const savedWebContentsInit = WebContents.prototype._init;
 

--- a/test/data/test-app-regular/index.js
+++ b/test/data/test-app-regular/index.js
@@ -12,7 +12,17 @@ var win = null;
 
 function createWindow () {
     // Create the browser window.
-    win = new BrowserWindow({ width: 1024, height: 768, webPreferences: { nodeIntegration: true } });
+    win = new BrowserWindow({
+        width:          1024,
+        height:         768,
+        webPreferences: {
+            nodeIntegration:    true,
+            // NOTE: Electron 10 breaking changes:
+            // "Changed the default value of `enableRemoteModule` to `false`"
+            // (https://www.electronjs.org/blog/electron-10-0#breaking-changes) (GH-73)
+            enableRemoteModule: true
+        }
+    });
 
     // and load the index.html of the app.
     win.webContents.loadURL('file://' + path.join(__dirname, 'index.html'));


### PR DESCRIPTION
Closes #73. 

### Changes
1. Updated the Electron version to `^11.0.3`.
2. Changed `loadURL` patching logic due to [these changes](https://github.com/electron/electron/pull/24325/files#diff-f6ca6a11b1d9a20b2f71e91a51c06f4956adb0eec9f07ac0705190f77c257211R437).
3. [Fixed binding naming](https://github.com/electron/electron/blob/v11.0.3/lib/browser/api/web-contents.ts#L123).
4. Switched on the `enableRemoteModule` ([Electron 10 breaking changes](https://www.electronjs.org/blog/electron-10-0#breaking-changes)).
5. Replaced `var` with `const` and `let` in src/injectable/electron-mocks.js.
6. The Travis CI config: changed the Ubuntu version from 14 (`trusty`) to 20 (`focal`), moved `xvfb` to services.
