### PR TITLE
Add the missing 'babel-core' dependency. Bump version (v0.0.16)

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
   },
   "devDependencies": {
     "asar": "^2.0.1",
+    "babel-core": "^6.26.3",
     "babel-eslint": "^7.2.3",
     "babel-plugin-add-module-exports": "^0.2.1",
     "babel-plugin-transform-runtime": "^6.23.0",
@@ -57,7 +58,7 @@
     "gulp-babel": "^7.0.0",
     "gulp-eslint": "^3.0.1",
     "publish-please": "^5.4.3",
-    "testcafe": "*",
+    "testcafe": "1.10.0-rc.6",
     "tmp": "0.0.28"
   },
   "types": "./ts-defs/index.d.ts"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "testcafe-browser-provider-electron",
-  "version": "0.0.15",
+  "version": "0.0.16",
   "description": "TestCafe browser provider plugin for testing applications built with Electron.",
   "repository": "https://github.com/DevExpress/testcafe-browser-provider-electron",
   "homepage": "https://github.com/DevExpress/testcafe-browser-provider-electron",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "gulp-babel": "^7.0.0",
     "gulp-eslint": "^3.0.1",
     "publish-please": "^5.4.3",
-    "testcafe": "1.10.0-rc.6",
+    "testcafe": "*",
     "tmp": "0.0.28"
   },
   "types": "./ts-defs/index.d.ts"


### PR DESCRIPTION
### Changes
1. Add the missing 'babel-core' dependency.
2. Bump version (v0.0.16)