### PR TITLE
update documentation for clickOnMainMenuItem

### DIFF
--- a/README.md
+++ b/README.md
@@ -359,7 +359,8 @@ fixture `Test Electron`
    .page('./index.html');
 
 test('Should open search panel', async t => {
-   await clickOnMainMenuItem(['Main Menu', 'Edit', 'Find...']);
+   const findMenuItem = await getMainMenuItem(['Main Menu', 'Edit', 'Find...']);
+   await clickOnMainMenuItem(findMenuItem);
 
    await searchPanel = Selector('.search-panel');
 


### PR DESCRIPTION
The current documentation suggests passing an array of strings to the helper function.
This doesn't seem to work and looking at the code the helper accepts an instance of a menu item, instead of an array of strings.

https://github.com/DevExpress/testcafe-browser-provider-electron/blob/0e6a93dd2e572829f78dddbba871dfbfafee9b5b/src/helpers.js#L86